### PR TITLE
feat: Explicit geography

### DIFF
--- a/src/OpenFoodFacts.php
+++ b/src/OpenFoodFacts.php
@@ -11,10 +11,10 @@ class OpenFoodFacts extends OpenFoodFactsApiWrapper
 {
     protected $max_results;
 
-    public function __construct(Container $app)
+    public function __construct(Container $app, string $geography = null)
     {
         parent::__construct([
-            'geography' =>  $app['config']->get('openfoodfacts.geography'),
+            'geography' =>  $geography ?? $app['config']->get('openfoodfacts.geography'),
             'app' =>  $app['config']->get('app.name'),
         ], $app['cache.store']);
 

--- a/tests/GeographyTest.php
+++ b/tests/GeographyTest.php
@@ -11,11 +11,13 @@ class GeographyTest extends Base\FacadeTestCase
     /** @test */
     public function it_returns_different_content_based_on_geography_parameter()
     {
+        $barcode = '8714200216964';
+
         $instanceWorld = app()->make(OpenFoodFacts::class);
-        $product_default_content = $instanceWorld->barcode('8714200216964');
+        $product_default_content = $instanceWorld->barcode($barcode);
 
         $instanceNL = app()->make(OpenFoodFacts::class, ['geography' => 'nl']);
-        $product_dutch_content = $instanceNL->barcode('8714200216964');
+        $product_dutch_content = $instanceNL->barcode($barcode);
 
         $this->assertEquals($product_default_content['_id'], $product_dutch_content['_id']);
         $this->assertNotEquals($product_default_content, $product_dutch_content);

--- a/tests/GeographyTest.php
+++ b/tests/GeographyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OpenFoodFacts\Laravel\Tests;
+
+use Illuminate\Support\Facades\Config;
+use OpenFoodFacts\Laravel\Facades\OpenFoodFacts as OpenFoodFactsFacade;
+use OpenFoodFacts\Laravel\OpenFoodFacts;
+
+class GeographyTest extends Base\FacadeTestCase
+{
+    /** @test */
+    public function it_returns_different_content_based_on_geography_parameter()
+    {
+        $instanceWorld = app()->make(OpenFoodFacts::class);
+        $product_default_content = $instanceWorld->barcode('8714200216964');
+
+        $instanceNL = app()->make(OpenFoodFacts::class, ['geography' => 'nl']);
+        $product_dutch_content = $instanceNL->barcode('8714200216964');
+
+        $this->assertEquals($product_default_content['_id'], $product_dutch_content['_id']);
+        $this->assertNotEquals($product_default_content, $product_dutch_content);
+    }
+
+    /** @test */
+    public function it_returns_geo_specific_content_through_config_setting()
+    {
+        Config::set('openfoodfacts.geography', 'nl');
+        $product_dutch_content = OpenFoodFactsFacade::barcode('8714200216964');
+
+        $this->assertStringContainsString('front_nl.', $product_dutch_content['image_url']);
+    }
+}


### PR DESCRIPTION
Addressing issue https://github.com/openfoodfacts/openfoodfacts-laravel/issues/14

Returns geographic content when optional parameter is set on instantiation.

e.g.:
```php
app()->make(OpenFoodFacts::class, ['geography' => 'nl'])->barcode($barcode_to_search_for);
```

PS. Ability to define default geography on config still remains, hence no breaking change.