### PR TITLE
fix: remove deprecated

### DIFF
--- a/src/OpenFoodFacts.php
+++ b/src/OpenFoodFacts.php
@@ -39,7 +39,7 @@ class OpenFoodFacts extends OpenFoodFactsApiWrapper
         try {
             $doc = $this->api->getProduct($value);
 
-            return empty($doc->code) ? [] : (array) reset($doc);
+            return empty($doc->code) ? [] : $doc->getData();
         } catch (ProductNotFoundException) {
             return [];
         }

--- a/src/OpenFoodFacts.php
+++ b/src/OpenFoodFacts.php
@@ -76,16 +76,7 @@ class OpenFoodFacts extends OpenFoodFactsApiWrapper
             $products = $products->concat($array);
         } while ($page < $pages);
 
-        return $products->map(function ($product) {
-            /**
-             * @var array $value
-             * Just to avoid error from phpstan :
-             * > Method OpenFoodFacts\Laravel\OpenFoodFacts::find() should return Illuminate\Support\Collection<int, array> but returns Illuminate\Support\Collection<int, array{bool}>.
-             */
-            $value = (array) reset($product);
-
-            return $value;
-        });
+        return $products->map(fn ($product) => $product->getData());
     }
 
     public function __call(string $method, array $parameters): mixed


### PR DESCRIPTION
### What
Just remove the deprecated use of `reset` and use `getData` instead

### Fixes bug(s)
#61 

