### PR TITLE
feat: Laravel 12.x Compatibility with updated Dependencies & Pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,18 @@
 name: CI
+
 on:
   push:
   pull_request:
+
 jobs:
   tests:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
         php: [8.1, 8.2]
-        laravel: [11.*, 10.*, 9.*]
+        laravel: ['9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-stable]
         include:
           - laravel: 11.*
@@ -18,45 +21,60 @@ jobs:
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 12.*
+            testbench: 10.*
         exclude:
           - laravel: 11.*
             php: 8.1
+          - laravel: 12.*
+            php: 8.1
+
     name: Tests - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 10
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, xdebug
           coverage: xdebug
+
       - name: Report PHP version
         run: php -v
+
       - name: Get Composer Cache Directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
       - name: Cache dependencies
         uses: actions/cache@v4.1.2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ matrix.php }}-composer-
+
       - name: Install Composer dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
       - name: Check quality code
         env:
-            PHP_CS_FIXER_IGNORE_ENV: 1
+          PHP_CS_FIXER_IGNORE_ENV: 1
         run: vendor/bin/php-cs-fixer fix --ansi --dry-run --using-cache=no --verbose
+
       - name: Execute phpstan
         run: vendor/bin/phpstan
+
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover ./build/coverage.clover
+
       - name: Uploading code coverage to scrutinize
         uses: sudo-bot/action-scrutinizer@latest
         with:
-            cli-args: "--format=php-clover build/coverage.clover"
+          cli-args: --format=php-clover build/coverage.clover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,18 @@
 name: CI
+
 on:
   push:
   pull_request:
+
 jobs:
   tests:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
         php: [8.1, 8.2]
-        laravel: [11.*, 10.*, 9.*]
+        laravel: ['9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-stable]
         include:
           - laravel: 11.*
@@ -18,45 +21,60 @@ jobs:
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 12.*
+            testbench: 10.*
         exclude:
           - laravel: 11.*
             php: 8.1
+          - laravel: 12.*
+            php: 8.1
+
     name: Tests - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 10
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, xdebug
           coverage: xdebug
+
       - name: Report PHP version
         run: php -v
+
       - name: Get Composer Cache Directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
       - name: Cache dependencies
         uses: actions/cache@v4.2.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ matrix.php }}-composer-
+
       - name: Install Composer dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
       - name: Check quality code
         env:
-            PHP_CS_FIXER_IGNORE_ENV: 1
+          PHP_CS_FIXER_IGNORE_ENV: 1
         run: vendor/bin/php-cs-fixer fix --ansi --dry-run --using-cache=no --verbose
+
       - name: Execute phpstan
         run: vendor/bin/phpstan
+
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover ./build/coverage.clover
+
       - name: Uploading code coverage to scrutinize
         uses: sudo-bot/action-scrutinizer@latest
         with:
-            cli-args: "--format=php-clover build/coverage.clover"
+          cli-args: --format=php-clover build/coverage.clover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
         laravel: ['9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-stable]
         include:
+          - laravel: 12.*
+            testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 12.*
-            testbench: 10.*
         exclude:
           - laravel: 11.*
             php: 8.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         laravel: ['9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-stable]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         laravel: ['9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
         exclude:

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.cache
 .phpunit.result.cache
 .php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "phpstan/phpstan": "^1.10|^2.1",
         "phpstan/phpstan-phpunit": "^1.3|^2.0",
-        "phpunit/phpunit": "^9.5.21|^10.5"
+        "phpunit/phpunit": "^9.5.21|^10.5|^11.5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.4",
-        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
         "openfoodfacts/openfoodfacts-php": "^0.3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9.5",
         "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpunit/phpunit": "^9.5.21|^10.5"
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "phpstan/phpstan": "^1.10|^2.1",
+        "phpstan/phpstan-phpunit": "^1.3|^2.0",
+        "phpunit/phpunit": "^9.5.21|^10.5|^11.5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9.5",
-        "larastan/larastan": "^2.9",
+        "larastan/larastan": "^2.9|^3.1",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "phpstan/phpstan": "^1.10|^2.1",
         "phpstan/phpstan-phpunit": "^1.3|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "phpstan/phpstan": "^1.10|^2.1",
         "phpstan/phpstan-phpunit": "^1.3|^2.0",
-        "phpunit/phpunit": "^9.5.21|^10.5|^11.5.3"
+        "phpunit/phpunit": "^9.5.21|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9.5",
-        "larastan/larastan": "^2.9",
+        "larastan/larastan": "^2.9|^3.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "phpstan/phpstan": "^1.10|^2.1",
         "phpstan/phpstan-phpunit": "^1.3|^2.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,7 @@ includes:
 
 parameters:
   level: 9
+  reportUnmatchedIgnoredErrors: false
   paths:
     - src
     - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ parameters:
     - src
     - tests
   ignoreErrors:
+    - identifier: method.alreadyNarrowedType
     - identifier: missingType.iterableValue
     -
       message: "#^Cannot access offset '[a-z.]+' on Illuminate\\\\Contracts\\\\Container\\\\Container.$#"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <source>
-    <include>
-        <directory suffix=".php">src</directory>
-    </include>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/coverage" lowUpperBound="35" highLowerBound="70"/>
@@ -23,4 +15,9 @@
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <source>
+    <include>
+        <directory suffix=".php">src</directory>
+    </include>
+  </source>
   <coverage>
     <include>
       <directory suffix=".php">src/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/coverage" lowUpperBound="35" highLowerBound="70"/>
@@ -18,4 +15,9 @@
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <source>
-    <include>
-        <directory suffix=".php">src</directory>
-    </include>
-  </source>
   <coverage>
     <include>
       <directory suffix=".php">src/</directory>

--- a/src/Facades/OpenBeautyFacts.php
+++ b/src/Facades/OpenBeautyFacts.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static array barcode(string $value)
- * @method static \Illuminate\Support\Collection find(string $searchTerm)
+ * @method static \Illuminate\Support\Collection<int, array> find(string $searchTerm)
  * @method static \OpenFoodFacts\Document getProduct(string $barcode)
  *
  * @see \OpenFoodFacts\Laravel\OpenFoodFacts

--- a/src/Facades/OpenFoodFacts.php
+++ b/src/Facades/OpenFoodFacts.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static array barcode(string $value)
- * @method static \Illuminate\Support\Collection find(string $searchTerm)
+ * @method static \Illuminate\Support\Collection<int, array> find(string $searchTerm)
  * @method static \OpenFoodFacts\Document getProduct(string $barcode)
  *
  * @see \OpenFoodFacts\Laravel\OpenFoodFacts

--- a/src/Facades/OpenPetFoodFacts.php
+++ b/src/Facades/OpenPetFoodFacts.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static array barcode(string $value)
- * @method static \Illuminate\Support\Collection find(string $searchTerm)
+ * @method static \Illuminate\Support\Collection<int, array> find(string $searchTerm)
  * @method static \OpenFoodFacts\Document getProduct(string $barcode)
  *
  * @see \OpenFoodFacts\Laravel\OpenFoodFacts

--- a/src/OpenFoodFacts.php
+++ b/src/OpenFoodFacts.php
@@ -82,13 +82,12 @@ class OpenFoodFacts extends OpenFoodFactsApiWrapper
 
         return $products->map(function ($product) {
             /**
-             * @var array $value
              * Just to avoid error from phpstan :
              * > Method OpenFoodFacts\Laravel\OpenFoodFacts::find() should return Illuminate\Support\Collection<int, array> but returns Illuminate\Support\Collection<int, array{bool}>.
              */
-            $value = (array) reset($product);
 
-            return $value;
+            return (array) reset($product);
+
         });
     }
 

--- a/src/OpenFoodFacts.php
+++ b/src/OpenFoodFacts.php
@@ -14,7 +14,7 @@ class OpenFoodFacts extends OpenFoodFactsApiWrapper
 {
     protected int $max_results;
 
-    public function __construct(Container $app, string $geography = null, string $environment = 'food')
+    public function __construct(Container $app, ?string $geography = null, string $environment = 'food')
     {
         parent::__construct(
             [

--- a/src/OpenFoodFacts.php
+++ b/src/OpenFoodFacts.php
@@ -84,6 +84,7 @@ class OpenFoodFacts extends OpenFoodFactsApiWrapper
             // SonarQube vs. Phpstan
             $value = reset($product);
             $value = (array) $value;
+
             /**
              * @var array $value
              * Just to avoid error from phpstan :

--- a/src/OpenFoodFacts.php
+++ b/src/OpenFoodFacts.php
@@ -81,13 +81,15 @@ class OpenFoodFacts extends OpenFoodFactsApiWrapper
         } while ($page < $pages);
 
         return $products->map(function ($product) {
+            // SonarQube vs. Phpstan
+            $value = reset($product);
+            $value = (array) $value;
             /**
+             * @var array $value
              * Just to avoid error from phpstan :
              * > Method OpenFoodFacts\Laravel\OpenFoodFacts::find() should return Illuminate\Support\Collection<int, array> but returns Illuminate\Support\Collection<int, array{bool}>.
              */
-
-            return (array) reset($product);
-
+            return $value;
         });
     }
 


### PR DESCRIPTION
### What
- adds Support for Laravel 12.x & PHP 8.4 



Superseeds #63 


(as I have not yet worked with laravel-shift before this new PR might "just" be a duplicate of a different working style)