### PR TITLE
feat: Add Laravel 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: ['11.*', '12.*']
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: ['11.*', '12.*', '13.*']
         dependency-version: [prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - php: 8.2
+            laravel: '13.*'
 
     name: Tests - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.4",
-        "illuminate/support": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "openfoodfacts/openfoodfacts-php": "^0.3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9.5",
         "larastan/larastan": "^2.9|^3.1",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "phpstan/phpstan": "^1.10|^2.1",
         "phpstan/phpstan-phpunit": "^1.3|^2.0",
-        "phpunit/phpunit": "^9.5.21|^10.5|^11.5.3"
+        "phpunit/phpunit": "^10.5|^11.5.3|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
     <report>
       <clover outputFile="build/logs/clover.xml"/>

--- a/tests/BarcodeFindTest.php
+++ b/tests/BarcodeFindTest.php
@@ -3,17 +3,18 @@
 namespace OpenFoodFacts\Laravel\Tests;
 
 use OpenFoodFacts\Laravel\Facades\OpenFoodFacts;
+use PHPUnit\Framework\Attributes\Test;
 
-class BarcodeFindTest extends Base\FacadeTestCase
+final class BarcodeFindTest extends Base\FacadeTestCase
 {
-    /** @test */
+    #[Test]
     public function it_returns_an_array_with_data_when_product_found(): void
     {
         $arr = OpenFoodFacts::barcode('0737628064502');
         $this->assertArrayHasKey('code', $arr);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_an_empty_array_when_product_not_found(): void
     {
         $arr = OpenFoodFacts::barcode('this-barcode-does-not-exist');
@@ -21,7 +22,7 @@ class BarcodeFindTest extends Base\FacadeTestCase
         $this->assertEquals([], $arr);
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_an_exception_when_argument_empty(): void
     {
         $this->expectException('InvalidArgumentException');

--- a/tests/FacadeBridgeToApiTest.php
+++ b/tests/FacadeBridgeToApiTest.php
@@ -4,10 +4,11 @@ namespace OpenFoodFacts\Laravel\Tests;
 
 use OpenFoodFacts\Document;
 use OpenFoodFacts\Laravel\Facades\OpenFoodFacts;
+use PHPUnit\Framework\Attributes\Test;
 
-class FacadeBridgeToApiTest extends Base\FacadeTestCase
+final class FacadeBridgeToApiTest extends Base\FacadeTestCase
 {
-    /** @test */
+    #[Test]
     public function it_calls_method_on_vendor_apiclass(): void
     {
         $doc = OpenFoodFacts::getProduct('0737628064502');

--- a/tests/GeographyTest.php
+++ b/tests/GeographyTest.php
@@ -5,10 +5,11 @@ namespace OpenFoodFacts\Laravel\Tests;
 use Illuminate\Support\Facades\Config;
 use OpenFoodFacts\Laravel\Facades\OpenFoodFacts as OpenFoodFactsFacade;
 use OpenFoodFacts\Laravel\OpenFoodFacts;
+use PHPUnit\Framework\Attributes\Test;
 
-class GeographyTest extends Base\FacadeTestCase
+final class GeographyTest extends Base\FacadeTestCase
 {
-    /** @test */
+    #[Test]
     public function it_returns_different_content_based_on_geography_parameter(): void
     {
         $barcode = '8714200216964';
@@ -23,7 +24,7 @@ class GeographyTest extends Base\FacadeTestCase
         $this->assertNotEquals($product_default_content, $product_dutch_content);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_geo_specific_content_through_config_setting(): void
     {
         Config::set('openfoodfacts.geography', 'nl');

--- a/tests/ProductSearchTest.php
+++ b/tests/ProductSearchTest.php
@@ -3,10 +3,11 @@
 namespace OpenFoodFacts\Laravel\Tests;
 
 use OpenFoodFacts\Laravel\Facades\OpenFoodFacts;
+use PHPUnit\Framework\Attributes\Test;
 
-class ProductSearchTest extends Base\FacadeTestCase
+final class ProductSearchTest extends Base\FacadeTestCase
 {
-    /** @test */
+    #[Test]
     public function it_returns_a_laravelcollection_with_arrays(): void
     {
         $results = OpenFoodFacts::find('Stir-Fry Rice Noodles');
@@ -20,17 +21,15 @@ class ProductSearchTest extends Base\FacadeTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_an_empty_laravelcollection_when_no_results_found(): void
     {
         $results = OpenFoodFacts::find('no-such-product-exists');
 
-        // Call to method PHPUnit\Framework\Assert::assertTrue() with bool will always evaluate to false.
-        // 💡 Because the type is coming from a PHPDoc
         $this->assertEquals(true, $results->isEmpty());
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_an_exception_on_too_many_results(): void
     {
         $this->expectException('Exception');
@@ -38,7 +37,7 @@ class ProductSearchTest extends Base\FacadeTestCase
         OpenFoodFacts::find('cola');
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_an_exception_when_argument_empty(): void
     {
         $this->expectException('InvalidArgumentException');


### PR DESCRIPTION
Add compatibility for Laravel 13.0 while maintaining support for Laravel 11 and 12.

## Changes

- Updated `illuminate/support` constraint to `^11.0|^12.0|^13.0`
- Updated `orchestra/testbench` to support versions `^9.0|^10.0|^11.0` (11.0 for Laravel 13)
- Updated `phpunit/phpunit` constraint to include `^12.0` for PHPUnit 12 compatibility
- Updated `phpunit.xml.dist` schema from 11.5 to 12.0 and removed the deprecated `stopOnFailure` attribute (invalid in PHPUnit 12)
- Extended CI workflow to test Laravel 13 with testbench 11.* and PHP 8.3+
- Added PHP 8.5 to the test matrix
- Configured matrix exclusion to prevent PHP 8.2 from running with Laravel 13 (Laravel 13 requires PHP 8.3+)

## Why

Laravel 13.0 was released and this package should support the latest version. The key compatibility changes are:
- PHPUnit 12 requires an updated XML schema and the removal of deprecated `stopOnFailure` attribute
- Laravel 13 requires PHP 8.3 as the minimum version
- Testbench 11.* is the version for Laravel 13 compatibility

This is a non-breaking change: existing Laravel 11 and 12 users will continue to work as before.